### PR TITLE
baseurl error and ansible playbook path

### DIFF
--- a/installation.adoc
+++ b/installation.adoc
@@ -120,6 +120,17 @@ section of the OpenShift documentation.
 yum -y install epel-release
 ----
 
+[NOTE]
+====
+if you get the following error message "ansible installer cannot find baseurl for repo base/7/x86_64 issue",
+it is a DNS issue. Try these commands:
+[source,bash,options="nowrap"]
+----
+ONBOOT=no
+dhclient
+----
+====
+
 . Optional but recommended: Update the newly installed system:
 +
 [source,bash,options="nowrap"]

--- a/installation.adoc
+++ b/installation.adoc
@@ -176,8 +176,8 @@ installation will take longer as the nodes are initially prepared.
 
 [NOTE]
 ====
-Download the openshift client (cli) and docker. Make sure that the client version that you downloaded
-can cluster up v3.6 cluster and above and that the docker version is appropriate for openshift.  
+Download the OpenShift client (cli) and docker. Make sure that the client version that you downloaded
+can cluster up v3.6 cluster and above and that the docker version is appropriate for OpenShift.  
 ====
 
 Once installed, the only user that exists in the system is the `system:admin`

--- a/installation.adoc
+++ b/installation.adoc
@@ -171,8 +171,17 @@ section below.
 ansible-playbook -i ./inventory.erb openshift-ansible/playbooks/byo/config.yml
 ----
 
++
+IMPORTANT: For the new version try ansible-playbook -i ./inventory.erb openshift-ansible/playbooks/deploy_cluster.yml
+
 The installation will run, displaying the typical ansible output. The first
 installation will take longer as the nodes are initially prepared.
+
+[NOTE]
+====
+Download the openshift client (cli) and docker. Make sure that the client version that you downloaded
+can cluster up v3.6 cluster and above and that the docker version is appropriate for openshift.  
+====
 
 Once installed, the only user that exists in the system is the `system:admin`
 user. The installer adds the necessary token to the `.kubeconfig` file of

--- a/installation.adoc
+++ b/installation.adoc
@@ -168,11 +168,8 @@ section below.
 +
 [source,bash,options="nowrap"]
 ----
-ansible-playbook -i ./inventory.erb openshift-ansible/playbooks/byo/config.yml
+ansible-playbook -i ./inventory.erb openshift-ansible/playbooks/deploy_cluster.yml
 ----
-
-+
-IMPORTANT: For the new version try ansible-playbook -i ./inventory.erb openshift-ansible/playbooks/deploy_cluster.yml
 
 The installation will run, displaying the typical ansible output. The first
 installation will take longer as the nodes are initially prepared.


### PR DESCRIPTION
While enabling EPEL repository using yum -y install epel-release, I received the following error: cannot find baseurl for repo base/7/x86_64 issue. It is a DNS issue.
I resolved it with the following commands
ONBOOT=no
dhclient

Also changed the path of the ansible playbook from 
ansible-playbook -i ./inventory.erb openshift-ansible/playbooks/byo/config.yml
to
ansible-playbook -i ./inventory.erb openshift-ansible/playbooks/deploy_cluster.yml